### PR TITLE
Remove glue collapse shim

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -11,10 +11,7 @@ col_in_df <- function(df, col) {
 
 # collapse helper to deal with naming change in the glue package
 collapse <- function(...) {
-  if (exists("glue_collapse", where=asNamespace("glue"), mode="function"))
     glue::glue_collapse(...)
-  else
-    glue::collapse(...)
 }
 
 # helper to make sure columns exist


### PR DESCRIPTION
glue 1.5.0 removes the previously deprecated function
`glue::collapse()`.

Once this happens your package will gain a NOTE

    *   checking dependencies in R code ... NOTE
        ```
        Missing or unexported object: ‘glue::collapse’
        ```

So removing the reference to `glue::collapse()` will fix that.