### PR TITLE
update test for dplyr 1.0.8

### DIFF
--- a/tests/testthat/test-file-info-operations.R
+++ b/tests/testthat/test-file-info-operations.R
@@ -130,7 +130,7 @@ test_that("Test that filtering by file info works", {
   expect_null(filter(iso_file1, new_info != 42))
   expect_equal(filter(iso_files, file_id == "A"), c(iso_file1))
   expect_null(filter(iso_files, file_id == "DNE"))
-  expect_error(filter(iso_files, dne == 5), "not.*found", class = "dplyr_error")
+  expect_error(filter(iso_files, dne == 5))
   
   # filter and iso_filter_files equivalence
   expect_equal(filter(iso_files, file_id != "A"), iso_filter_files(iso_files, file_id != "A"))


### PR DESCRIPTION
We're about to release dplyr 1.0.8, which changes a few things (for the better) about how it reports errors. 

Unfortunately, this appears to break this package with: 

````
> test_check("isoreader")
══ Skipped tests ═══════════════════════════════════════════════════════════════
• On CRAN (9)

══ Failed tests ════════════════════════════════════════════════════════════════
── Failure (test-file-info-operations.R:133:3): Test that filtering by file info works ──
`filter(iso_files, dne == 5)` threw an error with unexpected class and message.
Expected class: dplyr_error
Actual class:   rlang_error/error/condition
Message:        Problem while computing `..1 = dne == 5`.
Expected match: "not.*found"
Actual message: "Problem while computing `..1 = dne == 5`."
Backtrace:
     ▆
  1. ├─testthat::expect_error(...) at test-file-info-operations.R:133:2
  2. │ └─testthat:::quasi_capture(...)
  3. │   ├─testthat .capture(...)
  4. │   │ └─base::withCallingHandlers(...)
  5. │   └─rlang::eval_bare(quo_get_expr(.quo), quo_get_env(.quo))
  6. ├─dplyr::filter(iso_files, dne == 5)
  7. ├─isoreader:::filter.iso_file_list(iso_files, dne == 5)
  8. │ ├─isoreader::iso_filter_files(.data, ..., quiet = TRUE)
  9. │ └─isoreader:::iso_filter_files.iso_file_list(.data, ..., quiet = TRUE)
 10. │   └─iso_get_file_info(iso_files, quiet = TRUE) %>% ...
 11. ├─dplyr::filter(., ...)
 12. └─dplyr:::filter.data.frame(., ...)
 13.   └─dplyr:::filter_rows(.data, ..., caller_env = caller_env())
 14.     └─dplyr:::filter_eval(dots, mask = mask, error_call = error_call)
 15.       ├─base::withCallingHandlers(...)
 16.       └─mask$eval_all_filter(dots, env_filter)

[ FAIL 1 | WARN 0 | SKIP 9 | PASS 860 ]
Error: Test failures
Execution halted

1 error x | 0 warnings ✓ | 1 note x
````

Please consider releasing after merging this pull request. 